### PR TITLE
TestBlendingFunctionMoreThanOneSprite

### DIFF
--- a/core/src/main/java/com/ray3k/liftoff/Core.java
+++ b/core/src/main/java/com/ray3k/liftoff/Core.java
@@ -20,7 +20,8 @@ public class Core extends ApplicationAdapter {
     public static SpriteBatch spriteBatch;
     public static TenPatchDrawable background;
     public enum Mode {
-        NONE("None"), GL_SCISSOR("glScissor"), SCISSOR_STACK("ScissorStack"), DEPTH_BUFFER("Depth Buffer"), DEPTH_BUFFER_SHAPE_DRAWER("Depth Buffer w/ ShapeDrawer"), BLENDING_FUNCTION("Blending Function"), PIXMAPS("Pixmaps"), SHADER("Shader"), SHADER_VIDEO("Shader w/ Video"), BLEND_FUNC_SEPARATE("BlendFuncSeparate"), BLENDING_FUNCTION_TINTING("Blending Function Tinting");
+        NONE("None"), GL_SCISSOR("glScissor"), SCISSOR_STACK("ScissorStack"), DEPTH_BUFFER("Depth Buffer"), DEPTH_BUFFER_SHAPE_DRAWER("Depth Buffer w/ ShapeDrawer"), BLENDING_FUNCTION("Blending Function"), PIXMAPS("Pixmaps"), SHADER("Shader"), SHADER_VIDEO("Shader w/ Video"), BLEND_FUNC_SEPARATE("BlendFuncSeparate"), BLENDING_FUNCTION_TINTING("Blending Function Tinting"),
+        BLENDING_FUNCTION_MORE_THAN_ONE_SPRITE("Blending Function w/ More than one Sprite");
         private String name;
     
         Mode(String name) {
@@ -65,7 +66,7 @@ public class Core extends ApplicationAdapter {
         Array<Mode> modes = new Array<>();
         modes.addAll(Mode.NONE, Mode.GL_SCISSOR, Mode.SCISSOR_STACK, Mode.DEPTH_BUFFER, Mode.DEPTH_BUFFER_SHAPE_DRAWER,
                 Mode.BLENDING_FUNCTION, Mode.PIXMAPS, Mode.SHADER, Mode.SHADER_VIDEO, Mode.BLEND_FUNC_SEPARATE,
-                Mode.BLENDING_FUNCTION_TINTING);
+                Mode.BLENDING_FUNCTION_TINTING, Mode.BLENDING_FUNCTION_MORE_THAN_ONE_SPRITE);
         MenuWidget menuWidget = new MenuWidget(modes);
         stage.addActor(menuWidget);
         
@@ -109,6 +110,9 @@ public class Core extends ApplicationAdapter {
                 break;
             case BLENDING_FUNCTION_TINTING:
                 test = new TestBlendingFunctionTinting();
+                break;
+            case BLENDING_FUNCTION_MORE_THAN_ONE_SPRITE:
+                test = new TestBlendingFunctionMoreThanOneSprite();
                 break;
         }
         test.prep();

--- a/core/src/main/java/com/ray3k/liftoff/TestBlendingFunction.java
+++ b/core/src/main/java/com/ray3k/liftoff/TestBlendingFunction.java
@@ -26,35 +26,35 @@ public class TestBlendingFunction implements Test {
     private Array<Point> points;
     private FrameBuffer frameBuffer;
     private ScreenViewport frameBufferViewport;
-    
+
     @Override
     public void prep() {
         head = new Sprite(skin.getRegion("head-stationary"));
-        
+
         Array<TextureRegion> textures = new Array<>(skin.getRegions("head"));
         textures.addAll(skin.getRegions("head"));
         headAnimation = new Animation<>(.05f, textures, PlayMode.LOOP);
         animationTime = Float.MAX_VALUE;
-    
+
         donutSprite = new Sprite(skin.getRegion("donut"));
-        
+
         mask = new Sprite(skin.getRegion("bite"));
         points = new Array<>();
         frameBuffer = new FrameBuffer(Format.RGBA4444, donutSprite.getRegionWidth(), donutSprite.getRegionHeight(), false);
         frameBufferViewport = new ScreenViewport();
         frameBufferViewport.update(frameBuffer.getWidth(), frameBuffer.getHeight(), true);
     }
-    
+
     @Override
     public void act(float delta) {
         float x = Gdx.input.getX();
         float y = stage.getHeight() - Gdx.input.getY();
-        
+
         head.setPosition(x - 185, y - 70);
-        
+
         donutSprite.setPosition(stage.getWidth() - donutSprite.getRegionWidth(), stage.getHeight() / 2 - donutSprite.getRegionHeight() / 2f);
         frameBufferViewport.getCamera().position.set(donutSprite.getX() + donutSprite.getWidth() / 2, donutSprite.getY() + donutSprite.getHeight() / 2, 0);
-    
+
         animationTime += delta;
         if (Gdx.input.isButtonJustPressed(Buttons.LEFT)) {
             if (donutSprite.getBoundingRectangle().contains(x, y)) {
@@ -63,11 +63,11 @@ public class TestBlendingFunction implements Test {
                 points.add(new Point(x, y));
             }
         }
-    
+
         stage.act(delta);
         background.update(delta);
     }
-    
+
     @Override
     public void draw() {
         frameBuffer.begin();
@@ -75,12 +75,12 @@ public class TestBlendingFunction implements Test {
         spriteBatch.setProjectionMatrix(frameBufferViewport.getCamera().combined);
         spriteBatch.begin();
         ScreenUtils.clear(Color.CLEAR);
-        
+
         Gdx.gl.glColorMask(true, true, true, true);
         spriteBatch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
         donutSprite.draw(spriteBatch);
         spriteBatch.flush();
-        
+
         Gdx.gl.glColorMask(false, false, false, true);
         spriteBatch.setBlendFunction(GL20.GL_ZERO, GL20.GL_ONE_MINUS_SRC_ALPHA);
         for (Point point : points) {
@@ -89,35 +89,35 @@ public class TestBlendingFunction implements Test {
         }
         spriteBatch.end();
         frameBuffer.end();
-        
+
         stage.getViewport().apply();
         spriteBatch.setProjectionMatrix(stage.getCamera().combined);
         spriteBatch.begin();
         Gdx.gl.glColorMask(true, true, true, true);
         spriteBatch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
         background.draw(stage.getBatch(), 0, 0, stage.getWidth(), stage.getHeight());
-    
+
         if (!headAnimation.isAnimationFinished(animationTime)) {
             spriteBatch.draw(headAnimation.getKeyFrame(animationTime), Gdx.input.getX() - 185,
                     Gdx.graphics.getHeight() - Gdx.input.getY() - 70);
         } else {
             head.draw(spriteBatch);
         }
-    
+
         Texture texture = frameBuffer.getColorBufferTexture();
         TextureRegion textureRegion = new TextureRegion(texture);
         textureRegion.flip(false, true);
-        
+
         spriteBatch.draw(textureRegion, stage.getWidth() - textureRegion.getRegionWidth(), stage.getHeight() / 2 - textureRegion.getRegionHeight() / 2f);
         spriteBatch.end();
 
         stage.draw();
     }
-    
+
     private static class Point {
         public float x;
         public float y;
-        
+
         public Point(float x, float y) {
             this.x = x;
             this.y = y;


### PR DESCRIPTION
Exactly what the title says. It's hastily put together, and it shouldn't be merged into the main project, it's just something made to prove my point.

In my game, I needed a masking feature - and I did manage to implement it, by following this page on the wiki 
https://libgdx.com/wiki/graphics/2d/masking

I quickly realized however that any sprite drawn beneath the masked portion wouldn't draw properly - and I also figured out the fix by looking at the logic relating the color mask and the alpha channel. Basically, any sprite underneath the sprite that would be masked, requires `Gdx.gl.glColorMask(true, true, true, false)`; hold down the Space Bar while in the new test case to see the difference.

This does fix it & I did not notice any other with this being enabled on sprites when rendering **but I did not test this, shaders & other rendering features could very well break!**

The code in the wiki works,  but it's in a vacuum, i.e. it's extremely unlikely to be used with nothing else in the background that completely covers the mask. I also wasn't sure if I was messing something up on my own project, so I did this to make absolutely sure the weird rendering wasn't my fault, as I already had troubles with the masking feature much earlier (turns out I have to disable blending when rendering the frame to the screen)!

A better way around this is 
1) Masking into a FrameBuffer
2) Getting the Texture
3) Rendering that instead
This way you don't need to disable the alpha mask for the other sprites and it's also just straight-up easier

This is the reason why I made this pull request - Wiki should be updated with this information.